### PR TITLE
[Windows]Connect to ovsdb-server using named pipe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/Microsoft/hcsshim v0.8.6
-	github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20190103132138-cf96a9e61bd1
+	github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20200116135253-9bbdfadcd881
 	github.com/benmoss/go-powershell v0.0.0-20190925205200-09527df358ca
 	github.com/cenk/hub v1.0.1 // indirect
 	github.com/cenkalti/hub v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20190103132138-cf96a9e61bd1 h1:1JZQeXUs1wp2B7/cl8vbKMU6Z0behfe48c4wi9jnep8=
 github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20190103132138-cf96a9e61bd1/go.mod h1:J623KtHQCavhT3jhFh0wg5i6QQRdnsAxAlBrOY0TUMw=
+github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20200116135253-9bbdfadcd881 h1:6PUwmG2qZd1LNoe1WsdBmoJP2PseuC2P4QBGPTz6mQc=
+github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20200116135253-9bbdfadcd881/go.mod h1:J623KtHQCavhT3jhFh0wg5i6QQRdnsAxAlBrOY0TUMw=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/pkg/ovs/ovsconfig/default.go
+++ b/pkg/ovs/ovsconfig/default.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package ovsconfig
+
+const (
+	defaultConnNetwork = "unix"
+	defaultConnAddress = "/run/openvswitch/db.sock"
+	// Wait up to 1 second when get port
+	defaultGetPortTimeout = 1000
+)

--- a/pkg/ovs/ovsconfig/default_windows.go
+++ b/pkg/ovs/ovsconfig/default_windows.go
@@ -1,0 +1,9 @@
+package ovsconfig
+
+const (
+	defaultConnNetwork = "winpipe"
+	defaultConnAddress = `\\.\pipe\C:openvswitchvarrunopenvswitchdb.sock`
+	// Wait up to 2 seconds when get port, the operation of port creation
+	// cost more time on Windows platform than on Linux
+	defaultGetPortTimeout = 2000
+)

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -44,7 +44,6 @@ type OVSPortData struct {
 }
 
 const (
-	defaultUDSAddress = "/run/openvswitch/db.sock"
 	openvSwitchSchema = "Open_vSwitch"
 	// Openflow protocol version 1.0.
 	openflowProtoVersion10 = "OpenFlow10"
@@ -63,7 +62,7 @@ func NewOVSDBConnectionUDS(address string) (*ovsdb.OVSDB, Error) {
 	klog.Infof("Connecting to OVSDB at address %s", address)
 
 	if address == "" {
-		address = defaultUDSAddress
+		address = defaultConnAddress
 	}
 
 	// For the sake of debugging, we keep logging messages until the
@@ -88,7 +87,7 @@ func NewOVSDBConnectionUDS(address string) (*ovsdb.OVSDB, Error) {
 		}
 	}()
 
-	db := ovsdb.Dial([][]string{{"unix", address}}, nil, nil)
+	db := ovsdb.Dial([][]string{{defaultConnNetwork, address}}, nil, nil)
 	success <- true
 	return db, nil
 }
@@ -470,7 +469,7 @@ func (br *OVSBridge) GetOFPort(ifName string) (int32, Error) {
 
 	tx.Wait(dbtransaction.Wait{
 		Table:   "Interface",
-		Timeout: 1000, // Wait up to 1 second.
+		Timeout: defaultGetPortTimeout,
 		Columns: []string{"ofport"},
 		Until:   "!=",
 		Rows: []interface{}{map[string]interface{}{

--- a/test/integration/ovs/address.go
+++ b/test/integration/ovs/address.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package ovs
+
+const defaultOVSDBAddress = "/var/run/openvswitch/db.sock"

--- a/test/integration/ovs/address_windows.go
+++ b/test/integration/ovs/address_windows.go
@@ -1,0 +1,3 @@
+package ovs
+
+const defaultOVSDBAddress = `\\.\pipe\C:openvswitchvarrunopenvswitchdb.sock`

--- a/test/integration/ovs/ovs_client_test.go
+++ b/test/integration/ovs/ovs_client_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	defaultUDSAddress     = "/var/run/openvswitch/db.sock"
 	defaultBridgeName     = "br-antrea-test"
 	defaultConnectTimeout = 5 * time.Second
 )
@@ -235,7 +234,7 @@ func testDeletePort(t *testing.T, br *ovsconfig.OVSBridge, uuid string) {
 }
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&UDSAddress, "ovsdb-socket", defaultUDSAddress, "Unix domain server socket named file for OVSDB")
+	flag.StringVar(&UDSAddress, "ovsdb-socket", defaultOVSDBAddress, "Unix domain server socket named file for OVSDB")
 	flag.StringVar(&bridgeName, "br-name", defaultBridgeName, "Bridge name to use for tests")
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
On windows platform, ovsdb-server listens on a named pipe by default.
This patch change the connection to ovsdb-server from UDS to named
pipe on windows.

Signed-off-by: Rui Cao <704645806@qq.com>