### PR TITLE
CI for VM/BM use-case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ docker-tidy: $(DOCKER_CACHE)
 	@chmod -R 0755 $<
 	@chmod 0644 go.sum plugins/octant/go.sum
 
-ANTCTL_BINARIES := antctl-darwin antctl-linux antctl-windows
+ANTCTL_BINARIES := antctl-linux antctl-windows
 $(ANTCTL_BINARIES): antctl-%:
 	@GOOS=$* $(GO) build -o $(BINDIR)/$@ $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antctl
 	@if [[ $@ != *windows ]]; then \

--- a/build/charts/antrea/templates/controller/service.yaml
+++ b/build/charts/antrea/templates/controller/service.yaml
@@ -6,10 +6,16 @@ metadata:
   labels:
     app: antrea
 spec:
+  {{- if .Values.nodeport.enable }}
+  type: NodePort
+  {{- end }}
   ports:
     - port: 443
       protocol: TCP
       targetPort: api
+      {{- if .Values.nodeport.enable }}
+      nodePort: {{ .Values.nodeport.port }}
+      {{- end }}
   selector:
     app: antrea
     component: antrea-controller

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -264,3 +264,7 @@ testing:
   coverage: false
   simulator:
     enable: false
+
+nodeport:
+  enable: false
+  port: 32767

--- a/build/yamls/base/vm-agent-rbac.yaml
+++ b/build/yamls/base/vm-agent-rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vm-agent
-  namespace: vm-demo # Change the namespace to where vm-agent is expected to run.
+  namespace: test-ns # Change the namespace to where vm-agent is expected to run.
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -73,12 +73,6 @@ rules:
     verbs:
       - create
       - get
- - apiGroups:
-      - controlplane.antrea.io
-    resources:
-      - nodestatssummaries
-    verbs:
-      - create
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -91,4 +85,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: vm-agent
-    namespace: vm-demo # Change the namespace to where vm-agent is expected to run.
+    namespace: test-ns # Change the namespace to where vm-agent is expected to run.

--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+DOCKER_REGISTRY="projects.registry.vmware.com"
+DEFAULT_WORKDIR="/var/lib/jenkins"
+DEFAULT_KUBECONFIG_PATH=$DEFAULT_WORKDIR/kube.conf
+WORKDIR=$DEFAULT_WORKDIR
+KUBECONFIG_PATH=$DEFAULT_KUBECONFIG_PATH
+TEST_FAILURE=false
+MODE="report"
+
+# VM configuration
+WINDOWS_VM_IP=""
+UBUNTU_VM_IP=""
+LIN_HOSTNAME="vmbmtest0-1"
+WIN_HOSTNAME="vmbmtest0-win-0"
+
+# Cluster configuration
+CLUSTER_NAME="kubernetes"
+TEST_NAMESPACE="test-ns"
+SERVICE_ACCOUNT="vm-agent"
+
+# TODO: change to "control-plane" when testbeds are updated to K8s v1.20
+CONTROL_PLANE_NODE_ROLE="master"
+
+_usage="Usage: $0 [--kubeconfig <KubeconfigSavePath>] [--workdir <HomePath>]
+                  [--testcase <windows-install-ovs|windows-conformance|windows-networkpolicy|windows-e2e|e2e|conformance|networkpolicy|multicast-e2e>]
+
+Run K8s e2e community tests (Conformance & Network Policy) or Antrea e2e tests on a remote (Jenkins) Windows or Linux cluster.
+
+        --kubeconfig             Path of cluster kubeconfig.
+        --workdir                Home path for Go, vSphere information and antrea_logs during cluster setup. Default is $WORKDIR.
+        --testcase               Windows install OVS, Conformance and Network Policy or Antrea e2e testcases on a Windows or Linux cluster. It can also be flexible ipam or multicast e2e test.
+        --registry               The docker registry to use instead of dockerhub.
+        --proxyall               Enable proxyAll to test AntreaProxy.
+        --flexible-ipam          Run tests in flexible ipam mode"
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --kubeconfig)
+    KUBECONFIG_PATH="$2"
+    shift 2
+    ;;
+    --workdir)
+    WORKDIR="$2"
+    shift 2
+    ;;
+    --testcase)
+    TESTCASE="$2"
+    shift 2
+    ;;
+    --registry)
+    DOCKER_REGISTRY="$2"
+    shift 2
+    ;;
+    --proxyall)
+    PROXY_ALL=true
+    shift
+    ;;
+    --flexible-ipam)
+    FLEXIBLE_IPAM=true
+    shift
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+if [[ "$WORKDIR" != "$DEFAULT_WORKDIR" && "$KUBECONFIG_PATH" == "$DEFAULT_KUBECONFIG_PATH" ]]; then
+    KUBECONFIG_PATH=${WORKDIR}/.kube/config
+fi
+
+echo "Debug: WORKDIR = $WORKDIR"
+echo "Debug: DEFAULT_WORKDIR = $DEFAULT_WORKDIR"
+echo "Debug: KUBECONFIG_PATH = $KUBECONFIG_PATH"
+echo "Debug: DEFAULT_KUBECONFIG_PATH = $DEFAULT_KUBECONFIG_PATH"
+echo "Debug: DOCKER_REGISTRY = $DOCKER_REGISTRY"
+
+# To run kubectl cmds
+export KUBECONFIG=${KUBECONFIG_PATH}
+
+function export_govc_env_var {
+    # This should be coming from jenkins configuration
+    export GOVC_URL=$GOVC_URL
+    export GOVC_USERNAME=$GOVC_USERNAME
+    export GOVC_PASSWORD=$GOVC_PASSWORD
+    export GOVC_INSECURE=1
+    export GOVC_DATACENTER=$GOVC_DATACENTER
+    export GOVC_DATASTORE=$GOVC_DATASTORE
+}
+
+function clean_up_one_ns {
+    ns=$1
+    kubectl get pod -n "${ns}" --no-headers=true | awk '{print $1}' | while read pod_name; do
+        kubectl delete pod "${pod_name}" -n "${ns}" --force --grace-period 0
+    done
+    kubectl delete ns "${ns}" --ignore-not-found=true || true
+}
+
+function apply_antrea {
+    echo "====== Applying Antrea yaml ======"
+    ${WORKDIR}/hack/generate-manifest.sh --enable-nodeport > ${WORKDIR}/build/yamls/vm-antrea.yml
+    cp ${WORKDIR}/build/yamls/vm-antrea.yml /var/lib/jenkins/antrea.yml
+    kubectl apply -f /var/lib/jenkins/antrea.yml
+    sleep 30
+    kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 != role {print $6}' | while read IP; do
+        echo "Copy new antrea.yml to ${CONTROL_PLANE_NODE_ROLE} node ${IP} home directory"
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" /var/lib/jenkins/antrea.yml ubuntu@${IP}:~
+    done
+}
+
+function clean_vm_agent {
+    echo "====== Cleanup Antrea Installation on the VM ======"
+    echo "Revert to snapshot VMAgent"
+    govc snapshot.revert -k=true -vm=${LIN_HOSTNAME} VMAgent
+    govc snapshot.revert -k=true -vm=${WIN_HOSTNAME} VMAgent1
+    echo "Get IP addresses for VMs"
+    UBUNTU_VM_IP=$(govc vm.ip -k=true -wait=1m ${LIN_HOSTNAME})
+    WINDOWS_VM_IP=$(govc vm.ip -k=true -wait=1m ${WIN_HOSTNAME})
+    echo "Ip address for ubuntu VM ${UBUNTU_VM_IP} and windows VM ${WINDOWS_VM_IP}"
+    kubectl delete sa $SERVICE_ACCOUNT -n $TEST_NAMESPACE --ignore-not-found=true
+    clean_up_one_ns $TEST_NAMESPACE
+    # https://github.com/antrea-io/antrea/issues/1577
+    kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 != role {print $6}' | while read IP; do
+        CLEAN_LIST=("/tmp/antrea-agent.exe" "/tmp/antctl.exe" "/tmp/antrea-agent.conf" "/tmp/antrea-agent.*kubeconfig" "/tmp/antctl")
+        for file in "${CLEAN_LIST[@]}"; do
+            echo "Deleting stale antrea-agent file ${file} from ${UBUNTU_VM_IP} and ${WINDOWS_VM_IP}"
+            ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "rm -f ${file}"
+            ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "rm -f ${file}"
+        done
+    done
+}
+
+function configure_vm_agent {
+    echo "====== Configuring Antrea agent on the VM ======"
+    echo "Create ns $TEST_NAMESPACE"
+    kubectl create ns $TEST_NAMESPACE
+    echo "Create service account $SERVICE_ACCOUNT"
+    kubectl create sa $SERVICE_ACCOUNT -n $TEST_NAMESPACE
+    cp ${WORKDIR}/build/yamls/base/vm-agent-rbac.yaml /var/lib/jenkins/vm-agent-rbac.yaml
+    echo "Applying vm-agent rbac yaml"
+    kubectl apply -f /var/lib/jenkins/vm-agent-rbac.yaml
+    echo "Creating files antrea-agent.kubeconfig and antrea-agent.antrea.kubeconfig"
+
+    # Kubeconfig to access K8S API
+    APISERVER=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$CLUSTER_NAME\")].cluster.server}")
+    TOKEN=$(kubectl -n test-ns get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].data.token}"|base64 --decode)
+    kubectl config --kubeconfig=antrea-agent.kubeconfig set-cluster kubernetes --server=$APISERVER --insecure-skip-tls-verify=true
+    kubectl config --kubeconfig=antrea-agent.kubeconfig set-credentials antrea-agent --token=$TOKEN
+    kubectl config --kubeconfig=antrea-agent.kubeconfig set-context antrea-agent@kubernetes --cluster=kubernetes --user=antrea-agent
+    kubectl config --kubeconfig=antrea-agent.kubeconfig use-context antrea-agent@kubernetes
+
+    # Kubeconfig to access AntreaController
+    ANTREA_API_SERVER_IP=$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 != role {print $6}')
+    ANTREA_API_SERVER="https://${ANTREA_API_SERVER_IP}:32767"
+    TOKEN=$(kubectl -n test-ns get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].data.token}"|base64 --decode)
+    kubectl config --kubeconfig=antrea-agent.antrea.kubeconfig set-cluster antrea --server=$ANTREA_API_SERVER --insecure-skip-tls-verify=true
+    kubectl config --kubeconfig=antrea-agent.antrea.kubeconfig set-credentials antrea-agent --token=$TOKEN
+    kubectl config --kubeconfig=antrea-agent.antrea.kubeconfig set-context antrea-agent@antrea --cluster=antrea --user=antrea-agent
+    kubectl config --kubeconfig=antrea-agent.antrea.kubeconfig use-context antrea-agent@antrea
+
+    echo "Copying kubeconfig files to linux VM"
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.antrea.kubeconfig ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-agent.antrea.kubeconfig
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.kubeconfig  ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-agent.kubeconfig
+    echo "Copying kubeconfig files to windows VM"
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.antrea.kubeconfig Administrator@${WINDOWS_VM_IP}:/tmp/antrea-agent.antrea.kubeconfig
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.kubeconfig Administrator@${WINDOWS_VM_IP}:/tmp/antrea-agent.kubeconfig
+    echo "Configure antrea-agent as a service on linux VM"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo cp /tmp/antrea-agent /usr/sbin/"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo cp /tmp/antrea-agent.conf /var/run/antrea/"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo cp /tmp/antrea-agent.*kubeconfig /var/run/antrea/"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo systemctl daemon-reload"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo systemctl enable antrea-agent"
+    echo "Configure antrea-agent as a service on windows VM"
+    # change /tmp/*kubeconfig to C:\antrea-agent\*kubeconfig
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "sed -i 's/\/tmp\//C:\\\antrea-agent\\\/g' /tmp/antrea-agent.conf"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "cp /tmp/antrea-agent.exe C:/antrea-agent/"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "cp /tmp/antrea-agent.conf C:/antrea-agent/antrea-agent.conf"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "cp /tmp/antrea-agent.*kubeconfig C:/antrea-agent/"
+}
+
+
+function run_e2e_vms {
+    export GO111MODULE=on
+    export GOPATH=${WORKDIR}/go
+    export GOROOT=/usr/local/go
+    export GOCACHE=${WORKDIR}/.cache/go-build
+    export PATH=$GOROOT/bin:$PATH
+
+    configure_vm_agent
+    echo "====== Running Antrea e2e Tests for VM ======"
+    go test -v "${WORKDIR}/test/e2e" -run=TestVMAgent -provider=remote -winVMs=${WIN_HOSTNAME} -linVMs=${LIN_HOSTNAME}
+}
+
+function deliver_antrea_vm {
+    export_govc_env_var
+    clean_vm_agent
+    echo "====== Building Antrea binaries for the Following Commit ======"
+    export GO111MODULE=on
+    export GOPATH=${WORKDIR}/go
+    export GOROOT=/usr/local/go
+    export GOCACHE=${WORKSPACE}/../gocache
+    export PATH=${GOROOT}/bin:$PATH
+
+    cd ${WORKDIR}
+    make docker-bin
+    make antctl
+    make docker-windows-bin
+    echo "====== Delivering Antrea to all the VMs ======"
+    echo "Updating antrea-agent.conf"
+    sed -i 's|#namespace: default|namespace: test-ns|g' ${WORKDIR}/build/yamls/externalnode/conf/antrea-agent.conf
+    sed -i 's|kubeconfig: |kubeconfig: /tmp/|g' ${WORKDIR}/build/yamls/externalnode/conf/antrea-agent.conf
+    echo "Copying binaries and conf to linux VM: $UBUNTU_VM_IP"
+    scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/bin/antrea-agent ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-agent
+    scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/bin/antctl-linux ubuntu@${UBUNTU_VM_IP}:/tmp/antctl
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/build/yamls/externalnode/conf/antrea-agent.conf  ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-agent.conf
+    echo "Copying binaries and conf to windows VM: $WINDOWS_VM_IP"
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/bin/antrea-agent.exe Administrator@${WINDOWS_VM_IP}:/tmp/antrea-agent.exe
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/bin/antctl-windows.exe Administrator@${WINDOWS_VM_IP}:/tmp/antrea-windows.exe
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/build/yamls/externalnode/conf/antrea-agent.conf  Administrator@${WINDOWS_VM_IP}:/tmp/antrea-agent.conf
+}
+
+apply_antrea
+deliver_antrea_vm
+run_e2e_vms

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -46,6 +46,7 @@ Generate a YAML manifest for Antrea using Helm and print it to stdout.
         --help, -h                    Print this message and exit
         --multicast                   Generates a manifest for multicast.
         --multicast-interfaces        Multicast interface names (default is empty)
+        --enable-nodeport             Configure antrea-controller service as nodeport
 
 In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
 
@@ -87,6 +88,7 @@ WHEREABOUTS=false
 FLEXIBLE_IPAM=false
 MULTICAST=false
 MULTICAST_INTERFACES=""
+ENABLE_NODEPORT=false
 
 while [[ $# -gt 0 ]]
 do
@@ -192,6 +194,10 @@ case $key in
     --multicast-interfaces)
     MULTICAST_INTERFACES="$2"
     shift 2
+    ;;
+    --enable-nodeport)
+    ENABLE_NODEPORT=true
+    shift
     ;;
     -h|--help)
     print_usage
@@ -369,6 +375,10 @@ fi
 
 if $WHEREABOUTS; then
     HELM_VALUES+=("whereabouts.enable=true")
+fi
+
+if $ENABLE_NODEPORT; then
+    HELM_VALUES+=("nodeport.enable=true" "nodeport.port=32767")
 fi
 
 if [ "$MODE" == "dev" ]; then

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -378,6 +378,58 @@ func exportLogs(tb testing.TB, data *TestData, logsSubDir string, writeNodeLogs 
 	}); err != nil {
 		tb.Logf("Error when exporting kubelet logs: %v", err)
 	}
+
+	getVmWriter := func(nodeName, suffix string) *os.File {
+		logFile := filepath.Join(logsDir, fmt.Sprintf("%s-%s", nodeName, suffix))
+		f, err := os.Create(logFile)
+		if err != nil {
+			tb.Errorf("Error when creating log file '%s': '%v'", logFile, err)
+			return nil
+		}
+		return f
+	}
+
+	if testOptions.linVMs != "" {
+		//Export logs for linux VMs.
+		var cmd string
+		vms := strings.Split(testOptions.linVMs, ",")
+		for _, vm := range vms {
+			tb.Logf("Exporting logs from %s", vm)
+			cmd = "sudo cat /var/log/antrea/antrea-agent.log"
+			_, stdout, _, err := data.provider.RunCommandOnVM(vm, cmd)
+			if err != nil {
+				tb.Logf("Error when exporting antrea-agent logs from %s: Erro %+v", vm, err)
+			}
+			w := getVmWriter(vm, "antrea-agent")
+			if w == nil {
+				// move on to the next VM
+				continue
+			}
+			defer w.Close()
+			w.WriteString(stdout)
+		}
+	}
+
+	if testOptions.winVMs != "" {
+		//Export logs for windows VMs
+		var cmd string
+		vms := strings.Split(testOptions.winVMs, ",")
+		for _, vm := range vms {
+			tb.Logf("Exporting logs from %s", vm)
+			cmd = "cat c:/antrea-agent/antrea-agent.log"
+			_, stdout, _, err := data.provider.RunCommandOnVM(vm, cmd)
+			if err != nil {
+				tb.Logf("Error when exporting antrea-agent logs from %s: Error %+v", vm, err)
+			}
+			w := getVmWriter(vm, "antrea-agent")
+			if w == nil {
+				// move on to the next VM
+				continue
+			}
+			defer w.Close()
+			w.WriteString(stdout)
+		}
+	}
 }
 
 func teardownFlowAggregator(tb testing.TB, data *TestData) {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -183,6 +183,8 @@ type TestOptions struct {
 	enableAntreaIPAM    bool
 	coverageDir         string
 	skipCases           string
+	linVMs              string
+	winVMs              string
 }
 
 var testOptions TestOptions

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -83,6 +83,8 @@ func testMain(m *testing.M) int {
 	flag.BoolVar(&testOptions.enableAntreaIPAM, "antrea-ipam", false, "Run tests with AntreaIPAM")
 	flag.StringVar(&testOptions.coverageDir, "coverage-dir", "", "Directory for coverage data files")
 	flag.StringVar(&testOptions.skipCases, "skip", "", "Key words to skip cases")
+	flag.StringVar(&testOptions.linVMs, "linVMs", "", "hostname of linux VMs")
+	flag.StringVar(&testOptions.winVMs, "winVMs", "", "hostname of windows VMs")
 	flag.Parse()
 
 	cleanupLogging := testOptions.setupLogging()

--- a/test/e2e/providers/interface.go
+++ b/test/e2e/providers/interface.go
@@ -20,5 +20,6 @@ type ProviderInterface interface {
 	RunCommandOnNode(nodeName string, cmd string) (code int, stdout string, stderr string, err error)
 	// RunCommandOnNodeExt supports passing environment variables and writing the input to stdin.
 	RunCommandOnNodeExt(nodeName, cmd string, envs map[string]string, stdin string, sudo bool) (code int, stdout string, stderr string, err error)
+	RunCommandOnVM(nodeName, cmd string) (code int, stdout string, stderr string, err error)
 	GetKubeconfigPath() (string, error)
 }

--- a/test/e2e/providers/kind.go
+++ b/test/e2e/providers/kind.go
@@ -46,6 +46,11 @@ func (provider *KindProvider) RunCommandOnNodeExt(nodeName, cmd string, envs map
 	return exec.RunDockerExecCommand(nodeName, cmd, "/root", envs, stdin)
 }
 
+func (provider *KindProvider) RunCommandOnVM(nodeName, cmd string) (
+	code int, stdout, stderr string, err error) {
+	return 0, "", "", nil
+}
+
 func (provider *KindProvider) GetKubeconfigPath() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/test/e2e/providers/remote.go
+++ b/test/e2e/providers/remote.go
@@ -68,6 +68,15 @@ func (p *RemoteProvider) RunCommandOnNodeExt(nodeName, cmd string, envs map[stri
 	return exec.RunSSHCommand(host, clientCfg, cmd, envs, stdin, sudo)
 }
 
+func (p *RemoteProvider) RunCommandOnVM(nodeName, cmd string) (
+	code int, stdout, stderr string, err error) {
+	host, clientCfg, err := convertConfig(p.sshConfig, nodeName)
+	if err != nil {
+		return 0, "", "", err
+	}
+	return exec.RunSSHCommand(host, clientCfg, cmd, nil, "", false)
+}
+
 func (p *RemoteProvider) GetKubeconfigPath() (string, error) {
 	return *remoteKubeconfig, nil
 }

--- a/test/e2e/providers/vagrant.go
+++ b/test/e2e/providers/vagrant.go
@@ -133,6 +133,11 @@ func (provider *VagrantProvider) RunCommandOnNodeExt(nodeName, cmd string, envs 
 	return exec.RunSSHCommand(host, config, cmd, envs, stdin, sudo)
 }
 
+func (provider *VagrantProvider) RunCommandOnVM(nodeName, cmd string) (
+	code int, stdout, stderr string, err error) {
+	return 0, "", "", nil
+}
+
 func (provider *VagrantProvider) GetKubeconfigPath() (string, error) {
 	vagrantPath, err := vagrantPath()
 	if err != nil {

--- a/test/e2e/utils/eespecbuilder.go
+++ b/test/e2e/utils/eespecbuilder.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ExternalEntitySpecSpecBuilder struct {
+	Spec      crdv1alpha2.ExternalEntitySpec
+	Name      string
+	Namespace string
+}
+
+func (t *ExternalEntitySpecSpecBuilder) SetName(namespace string, name string) *ExternalEntitySpecSpecBuilder {
+	t.Namespace = namespace
+	t.Name = name
+	return t
+}
+
+func (t *ExternalEntitySpecSpecBuilder) Get() *crdv1alpha2.ExternalEntity {
+	return &crdv1alpha2.ExternalEntity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.Name,
+			Namespace: t.Namespace,
+		},
+		Spec: t.Spec,
+	}
+}

--- a/test/e2e/utils/enodespecbuilder.go
+++ b/test/e2e/utils/enodespecbuilder.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ExternalNodeSpecBuilder struct {
+	Spec      crdv1alpha1.ExternalNodeSpec
+	Name      string
+	Namespace string
+}
+
+func (t *ExternalNodeSpecBuilder) SetName(namespace string, name string) *ExternalNodeSpecBuilder {
+	t.Namespace = namespace
+	t.Name = name
+	return t
+}
+
+func (t *ExternalNodeSpecBuilder) Get() *crdv1alpha1.ExternalNode {
+	return &crdv1alpha1.ExternalNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.Name,
+			Namespace: t.Namespace,
+		},
+		Spec: t.Spec,
+	}
+}

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -1,0 +1,361 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	. "antrea.io/antrea/test/e2e/utils"
+)
+
+type VmInfo struct {
+	Nodename string
+	OS       string
+	IfName   string
+	IP       string
+	IfIndex  string // Used only for windows
+}
+
+// TestBasic is the top-level test which contains some subtests for
+// basic test cases so they can share setup, teardown.
+func TestVMAgent(t *testing.T) {
+	skipIfHasWindowsNodes(t)
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	t.Run("testExternalEntityCommon", func(t *testing.T) { testExternalEntityCommon(t, data, "test-ns") })
+	//t.Run("testVMSupportBundle", func(t *testing.T) { testVMSupportBundle(t, data, "test-ns") })
+}
+
+func testExternalEntityCommon(t *testing.T, data *TestData, namespace string) {
+	t.Logf("List of Windows VMs: '%s'", testOptions.winVMs)
+	t.Logf("List of Linux VMs: '%s'", testOptions.linVMs)
+	nsReturned, _ := data.clientset.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
+	saReturned, _ := data.clientset.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), "vm-agent", metav1.GetOptions{})
+	t.Logf("Using service account %s", saReturned.Name)
+	t.Logf("Using name space %s", nsReturned.Name)
+	var VmList []VmInfo
+	if testOptions.linVMs != "" {
+		vms := strings.Split(testOptions.linVMs, ",")
+		for _, vm := range vms {
+			t.Logf("Get info for linux VM: %s", vm)
+			vmInfo := GetVmInfo(t, data, vm)
+			VmList = append(VmList, vmInfo)
+		}
+	}
+
+	if testOptions.winVMs != "" {
+		vms := strings.Split(testOptions.winVMs, ",")
+		for _, vm := range vms {
+			t.Logf("Get info for windows VM, %s", vm)
+			vmInfo := GetWindowsVmInfo(t, data, vm)
+			VmList = append(VmList, vmInfo)
+		}
+	}
+
+	t.Log("=== TestSetup ===")
+	for _, vm := range VmList {
+		// Stop antrea-agent service
+		StopAntreaAgent(t, data, vm)
+		t.Logf("Creating ExternalEntity for %+v", vm)
+		_, err := CreateExternalEntityCrd(data, nsReturned.Name, vm.Nodename, vm.IfName, vm.IP)
+		if err != nil {
+			t.Fatalf("ERROR! Failed to create ExternalEntity, %+v", err)
+		}
+
+		t.Logf("Creating ExternalNode for %+v", vm)
+		_, err = CreateExternalNodeCrd(data, nsReturned.Name, vm.Nodename, vm.IfName, vm.IP)
+		if err != nil {
+			t.Fatalf("ERROR! Failed to create ExternalNode, %+v", err)
+		}
+
+		StartAntreaAgent(t, data, vm)
+	}
+
+	t.Logf("Wait 120s for antrea-agent to startup and sync externalentities")
+	time.Sleep(120 * time.Second)
+	t.Logf("=== TestVerification ===")
+	for _, vm := range VmList {
+		t.Logf("Verify host interface configuration, VmInfo %+v", vm)
+		exists, err := VerifyInterfaceIsInOVS(t, data, vm)
+		if err != nil {
+			t.Errorf("ERROR! Failed to verify Host interface, VmInfo %+v", vm)
+		}
+		if exists {
+			t.Logf("Verified: Host interface %s is added in OVS", vm.IfName)
+		}
+
+		var info VmInfo
+		if vm.OS == "windows" {
+			info = GetWindowsVmInfo(t, data, vm.Nodename)
+		} else {
+			info = GetVmInfo(t, data, vm.Nodename)
+		}
+		if info.IP != vm.IP {
+			t.Errorf("ERROR! Failed to verify Host IP address, Expected %+v, Got %+v", vm, info)
+		} else {
+			t.Logf("Verified: Host interface %s has uplink's ip address %s", info.IfName, info.IP)
+		}
+	}
+
+	t.Logf("=== TestCleanUp ===")
+	for _, vm := range VmList {
+		if vm.OS == "windows" {
+			t.Logf("Skip Deleting ExternalEntity %s", vm.Nodename)
+			continue
+		}
+		t.Logf("Deleting ExternalEntity: %+v", vm.Nodename)
+		err := data.crdClient.CrdV1alpha2().ExternalEntities(nsReturned.Name).Delete(context.TODO(), vm.Nodename, metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatalf("ERROR! Failed to delete ExternalEntity, %+v", err)
+		}
+
+		t.Logf("Deleting ExternalNode: %+v", vm.Nodename)
+		err = data.crdClient.CrdV1alpha1().ExternalNodes(nsReturned.Name).Delete(context.TODO(), vm.Nodename, metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatalf("ERROR! Failed to delete ExternalNode, %+v", err)
+		}
+	}
+
+	t.Logf("Wait 30s for antrea-agent to sync externalentities")
+	time.Sleep(30 * time.Second)
+	t.Logf("=== Verification after TestCleanUp ===")
+	for _, vm := range VmList {
+		var currVm VmInfo
+		if vm.OS == "linux" {
+			currVm = GetVmInfo(t, data, vm.Nodename)
+		} else {
+			// Not required on windows, since externalEntity deletion
+			// will be a no-op for single interface use-case
+			//currVm = GetWindowsVmInfo(t, data, vm.Nodename)
+			continue
+		}
+
+		// Verify Uplink Interface Name
+		if currVm.IfName != vm.IfName {
+			t.Errorf("ERROR! Failed to verify uplink interface, Expected %+v, Got %+v", vm, currVm)
+		} else {
+			t.Logf("Verified: uplink interface is renamed to %s", vm.IfName)
+		}
+
+		// Verify  Uplink Interface IP
+		if currVm.IP != vm.IP {
+			t.Errorf("ERROR! Failed to verify uplink IP address, Expected %+v, Got %+v", vm, currVm)
+		} else {
+			t.Logf("Verified: uplink interface %s has IP address %s ", vm.IfName, vm.IP)
+		}
+
+	}
+	t.Log("Exiting the test")
+}
+
+func testVMSupportBundle(t *testing.T, data *TestData, namespace string) {
+	t.Logf("List of Windows VMs: '%s'", testOptions.winVMs)
+	t.Logf("List of Linux VMs: '%s'", testOptions.linVMs)
+	nsReturned, _ := data.clientset.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
+	saReturned, _ := data.clientset.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), "vm-agent", metav1.GetOptions{})
+	t.Logf("Using service account %s", saReturned.Name)
+	t.Logf("Using name space %s", nsReturned.Name)
+	var VmList []VmInfo
+	if testOptions.linVMs != "" {
+		vms := strings.Split(testOptions.linVMs, ",")
+		for _, vm := range vms {
+			t.Logf("Get info for linux VM: %s", vm)
+			vmInfo := GetVmInfo(t, data, vm)
+			VmList = append(VmList, vmInfo)
+		}
+	}
+
+	if testOptions.winVMs != "" {
+		vms := strings.Split(testOptions.winVMs, ",")
+		for _, vm := range vms {
+			t.Logf("Get info for windows VM, %s", vm)
+			vmInfo := GetWindowsVmInfo(t, data, vm)
+			VmList = append(VmList, vmInfo)
+		}
+	}
+
+	t.Log("=== TestSetup ===")
+	t.Log("Exiting the test")
+}
+
+func GetVmInfo(t *testing.T, data *TestData, nodeName string) (vm VmInfo) {
+	var err error
+	vm.Nodename = nodeName
+	var cmd string
+	cmd = "ip -o -4 route show to default | awk '{print $5}'"
+	vm.OS = "linux"
+	_, vm.IfName, _, err = data.provider.RunCommandOnVM(nodeName, cmd)
+	if err != nil {
+		t.Fatalf("ERROR! Failed to run command %s on VM %s, err %v", cmd, nodeName, err)
+	}
+	vm.IfName = strings.TrimSpace(vm.IfName)
+	cmd = fmt.Sprintf("ifconfig %s | awk '/inet / {print $2}'| sed 's/addr://'", vm.IfName)
+	_, vm.IP, _, err = data.provider.RunCommandOnVM(nodeName, cmd)
+	if err != nil {
+		t.Fatalf("ERROR! Failed to run command %s on VM %s, err %v", cmd, nodeName, err)
+	}
+	vm.IP = strings.TrimSpace(vm.IP)
+	return vm
+}
+
+func GetWindowsVmInfo(t *testing.T, data *TestData, nodeName string) (vm VmInfo) {
+	var err error
+	vm.Nodename = nodeName
+	vm.OS = "windows"
+	cmd := fmt.Sprintf("powershell 'Get-WmiObject -Class Win32_IP4RouteTable | Where { $_.destination -eq \"0.0.0.0\" -and $_.mask -eq \"0.0.0.0\"} | Sort-Object metric1 | select interfaceindex | ft -HideTableHeaders'")
+	_, ifIndex, _, err := data.provider.RunCommandOnVM(nodeName, cmd)
+	if err != nil {
+		t.Fatalf("ERROR! Failed to run command %s on VM %s, err %v", cmd, nodeName, err)
+	}
+	vm.IfIndex = strings.TrimSpace(ifIndex)
+	cmd = fmt.Sprintf("powershell 'Get-NetAdapter -IfIndex %s | select name | ft -HideTableHeaders'", vm.IfIndex)
+	_, ifName, _, err := data.provider.RunCommandOnVM(nodeName, cmd)
+	if err != nil {
+		t.Fatalf("ERROR! Failed to run command %s on VM %s, err %v", cmd, nodeName, err)
+	}
+	vm.IfName = strings.TrimSpace(ifName)
+	cmd = fmt.Sprintf("powershell 'Get-NetIPAddress -AddressFamily IPv4 -ifIndex %s| select IPAddress| ft -HideTableHeaders'", vm.IfIndex)
+	_, ifIP, _, err := data.provider.RunCommandOnVM(nodeName, cmd)
+	if err != nil {
+		t.Fatalf("ERROR! Failed to run command %s on VM %s, err %v", cmd, nodeName, err)
+	}
+	vm.IP = strings.TrimSpace(ifIP)
+	return vm
+
+}
+
+func StartAntreaAgent(t *testing.T, data *TestData, vm VmInfo) {
+	t.Logf("Starting antrea-agent on VM: %s", vm.Nodename)
+	var cmd string
+	if vm.OS == "windows" {
+		cmd = "nssm start antrea-agent"
+	} else {
+		cmd = "sudo systemctl start antrea-agent"
+	}
+	_, _, _, err := data.provider.RunCommandOnVM(vm.Nodename, cmd)
+	if err != nil {
+		t.Errorf("ERROR! Failed to run command %s on VM %s, err %v", cmd, vm.Nodename, err)
+	}
+}
+
+func StopAntreaAgent(t *testing.T, data *TestData, vm VmInfo) {
+	t.Logf("Stopping antrea-agent on VM: %s", vm.Nodename)
+	var cmd string
+	if vm.OS == "windows" {
+		cmd = "nssm stop antrea-agent"
+	} else {
+		cmd = "sudo systemctl stop antrea-agent"
+	}
+	_, _, _, err := data.provider.RunCommandOnVM(vm.Nodename, cmd)
+	if err != nil {
+		t.Errorf("ERROR! Failed to run command %s on VM %s, err %v", cmd, vm.Nodename, err)
+	}
+
+}
+
+func VerifyInterfaceIsInOVS(t *testing.T, data *TestData, vm VmInfo) (found bool, err error) {
+	var cmd string
+	if vm.OS == "windows" {
+		cmd = fmt.Sprintf("ovs-vsctl --column=name list port '%s'", vm.IfName)
+	} else {
+		cmd = fmt.Sprintf("sudo ovs-vsctl --column=name list port %s", vm.IfName)
+	}
+	_, out, _, err := data.provider.RunCommandOnVM(vm.Nodename, cmd)
+	if err != nil {
+		t.Errorf("ERROR! Failed to run command %s on VM %s, err %v", cmd, vm.Nodename, err)
+		return false, err
+	}
+
+	if strings.Contains(out, "no row") {
+		t.Errorf("ERROR! Failed to find ovs port %s on VM %s", vm.IfName, vm.Nodename)
+		return false, err
+	}
+
+	if strings.Contains(out, vm.IfName) && strings.Contains(out, "name") {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func CreateExternalEntityCrd(data *TestData, namespace string, nodename string, ifName string, ip string) (ee *crdv1alpha2.ExternalEntity, err error) {
+	testee := &ExternalEntitySpecSpecBuilder{}
+	testee.SetName(namespace, nodename)
+	testee.Spec.ExternalNode = nodename
+	testee.Spec.Endpoints = append(testee.Spec.Endpoints, crdv1alpha2.Endpoint{Name: ifName, IP: ip})
+	return data.crdClient.CrdV1alpha2().ExternalEntities(namespace).Create(context.TODO(), testee.Get(), metav1.CreateOptions{})
+}
+
+func CreateExternalNodeCrd(data *TestData, namespace string, nodename string, ifName string, ip string) (enode *crdv1alpha1.ExternalNode, err error) {
+	testen := &ExternalNodeSpecBuilder{}
+	testen.SetName(namespace, nodename)
+	var ipList []string
+	ipList = append(ipList, ip)
+	testen.Spec.Interfaces = append(testen.Spec.Interfaces, crdv1alpha1.NetworkInterface{
+		Name: ifName,
+		IPs:  ipList,
+	})
+	return data.crdClient.CrdV1alpha1().ExternalNodes(namespace).Create(context.TODO(), testen.Get(), metav1.CreateOptions{})
+}
+
+func VerifyInterfaceMoveInOVS(t *testing.T, data *TestData, hostName string, ifName string) (found bool, err error) {
+	cmd := fmt.Sprintf("ovs-vsctl --column=name,external_ids,_uuid list port %s", ifName)
+	_, stdout, _, err := data.provider.RunCommandOnVM(hostName, cmd)
+	if err != nil {
+		t.Logf("Error when Running command %s on VM: %v", cmd, err)
+		return false, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(stdout))
+	found = false
+	for scanner.Scan() {
+		temp := strings.Fields(scanner.Text())
+		line := strings.Join(temp, "")
+		line = strings.TrimSpace(line)
+		// Ignore empty lines
+		if len(line) == 0 {
+			continue
+		}
+		lineSplit := strings.Split(line, ":")
+		switch lineSplit[0] {
+		case "name":
+			t.Logf("name=%s\n", lineSplit[1])
+			found = true
+			break
+		case "external_ids":
+			t.Logf("external_ids=%s\n", lineSplit[1])
+			break
+		case "_uuid":
+			t.Logf("_uuid=%s\n", lineSplit[1])
+			break
+		default:
+			t.Logf("Unknown key!")
+		}
+	}
+	return found, nil
+}


### PR DESCRIPTION
Adding a new test for VM/BM agent.
- Test configures namespace, serviceaccount
- Applies vm-agent-rbac.yaml
- Starts antrea service as nodeport
- Verifies create/delete externalentity, validates interface
configurion in OVS

Signed-off-by: Anand Kumar <kumaranand@vmware.com>